### PR TITLE
Fix for checkSamsungPassSupport() callbacks never invoked on non-Samsung device

### DIFF
--- a/src/android/SamsungPassPlugin.java
+++ b/src/android/SamsungPassPlugin.java
@@ -33,18 +33,19 @@ public class SamsungPassPlugin extends CordovaPlugin {
         try {
             mSpass.initialize(this.cordova.getActivity().getApplicationContext());
             Log.d(TAG, "Spass was Initialized");
+
+            isFeatureEnabled = mSpass.isFeatureEnabled(Spass.DEVICE_FINGERPRINT);
+
+            if (isFeatureEnabled) {
+                mSpassFingerprint = new SpassFingerprint(this.cordova.getActivity().getApplicationContext());
+                Log.d(TAG, "mSpassFingerprint was Initialized");
+            } else {
+                Log.d(TAG, "Fingerprint Service is not supported in the device.");
+            }
         } catch (SsdkUnsupportedException e) {
             Log.d(TAG, "Spass could not initialize" + e);
         }
 
-        isFeatureEnabled = mSpass.isFeatureEnabled(Spass.DEVICE_FINGERPRINT);
-        
-        if (isFeatureEnabled) {
-            mSpassFingerprint = new SpassFingerprint(this.cordova.getActivity().getApplicationContext());
-            Log.d(TAG, "mSpassFingerprint was Initialized");
-        } else {
-            Log.d(TAG, "Fingerprint Service is not supported in the device.");
-        }
     }
 
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {


### PR DESCRIPTION
In the SamsungPassPlugin.initialize() method, a java exception occurs in the call to mSpass.isFeatureEnabled(). This causes the SamsungPass.checkSamsungPassSupport() javascript callbacks to never be invoked if run on a non-Samsung device.

To reproduce this bug, simply run the application code which calls SamsungPass.checkSamsungPassSupport() on the standard Android emulator. You can see the exception in the java log (not javascript console).

This pull-request fixes the bug by only calling mSpass.isFeatureEnabled() if mSpass.initialize() was successful.
